### PR TITLE
Fix TTSService caller signatures

### DIFF
--- a/fastrtc_jp/app.py
+++ b/fastrtc_jp/app.py
@@ -29,7 +29,8 @@ from fastrtc.text_to_speech.tts import TTSModel, TTSOptions
 
 from fastrtc_jp.handler.agent_handler import AgentSession, AgentHandler
 from fastrtc_jp.speech_to_text.sr_google import GoogleSTT
-from fastrtc_jp.text_to_speech.gtts import GTTSModel
+from fastrtc_jp.text_to_speech.gtts import GTTSModel, GTTSOptions
+from fastrtc_jp.text_to_speech.opt import SpkOptions
 from fastrtc_jp.handler.stream_handler import VadOptions, AsyncVoiceStreamHandler
 from fastrtc_jp.utils.util import load_dotenv, setup_logger
 from fastrtc_jp.handler.vad import VadOptions, VadHandler
@@ -40,9 +41,27 @@ from fastrtc_jp.handler.dummy import dummy_response
 logger = getLogger(__name__)
 
 
-def get_tts_model(profile:str) -> TTSModel:
-    print(f"get_tts_model: profile={profile}",flush=True)
+def get_tts_model(class_id:str, options:SpkOptions) -> TTSModel:
+    """Return a TTSModel instance.
+
+    This simple example ignores ``class_id`` and always returns ``GTTSModel``.
+    ``options`` is currently unused but kept for signature compatibility.
+    """
+    print(f"get_tts_model: class_id={class_id}", flush=True)
     return GTTSModel()
+
+
+def get_tts_options(class_id:str, options:SpkOptions) -> SpkOptions:
+    """Return ``SpkOptions`` for the given class.
+
+    The sample implementation converts the generic :class:`SpkOptions` into
+    :class:`GTTSOptions` used by :class:`GTTSModel`.
+    """
+    opts = GTTSOptions()
+    opts.lang = options.lang
+    opts.speedScale = options.speedScale
+    opts.pitchOffset = options.pitchOffset
+    return opts
 
 class GoogleSttHandler(SttHandler):
     def __init__(self,):
@@ -166,6 +185,7 @@ def test_speech_gr():
                 GoogleSttHandler(),
                 agent_hdr,
                 get_tts_model_fn=get_tts_model,
+                get_tts_options_fn=get_tts_options,
                 vad_options=algo_options,
             ),
             inputs=[audio,dropdown,slider],

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -8,6 +8,7 @@ import asyncio
 from fastrtc.text_to_speech.tts import TTSModel, TTSOptions
 from fastrtc.speech_to_text.stt_ import STTModel
 from fastrtc_jp.handler.service import STTService, TTSService
+from fastrtc_jp.text_to_speech.opt import SpkOptions
 
 
 def encode_text( text:str ) ->NDArray[np.float32]:
@@ -48,8 +49,11 @@ class DummyTTSModel(TTSModel):
         # Dummy generator
         yield self.tts(text,options)
 
-def get_dummy_tts_model():
+def get_dummy_tts_model(class_id:str, options:SpkOptions):
     return DummyTTSModel()
+
+def get_dummy_tts_options(class_id:str, options:SpkOptions) -> SpkOptions:
+    return options
 
 class TestProcessServices(unittest.IsolatedAsyncioTestCase):
     async def test_stt_service(self):
@@ -66,11 +70,11 @@ class TestProcessServices(unittest.IsolatedAsyncioTestCase):
 
     async def test_tts_service(self):
         text = "test"
-        options = {}
+        options = SpkOptions()
         expected_sr = 24000
         expected_audio = encode_text(text)
-        service = TTSService(get_dummy_tts_model)
-        sample_rate, audio = await service.tts(text, options)
+        service = TTSService(get_dummy_tts_model, get_dummy_tts_options)
+        sample_rate, audio = await service.tts("", options, text)
         self.assertEqual(sample_rate, expected_sr)
         self.assertIsInstance(audio, np.ndarray)
         np.testing.assert_array_equal(audio, expected_audio)


### PR DESCRIPTION
## Summary
- update get_tts_model to new signature and create get_tts_options
- wire new functions into AsyncVoiceStreamHandler
- update tests to use new TTSService API

## Testing
- `pytest -q` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413df1f90c8326a6e210fe12931ced